### PR TITLE
Changed RKStringTokenizer to allow tokenization of symbol characters …

### DIFF
--- a/Code/Support/RKStringTokenizer.m
+++ b/Code/Support/RKStringTokenizer.m
@@ -18,7 +18,7 @@
 
     // Remove diacratics and lowercase our input text
     NSString *tokenizeText = string = [string stringByFoldingWithOptions:kCFCompareCaseInsensitive|kCFCompareDiacriticInsensitive locale:[NSLocale systemLocale]];
-    CFStringTokenizerRef tokenizer = CFStringTokenizerCreate(kCFAllocatorDefault, (__bridge CFStringRef)tokenizeText, CFRangeMake(0, CFStringGetLength((__bridge CFStringRef)tokenizeText)), kCFStringTokenizerUnitWord, locale);
+    CFStringTokenizerRef tokenizer = CFStringTokenizerCreate(kCFAllocatorDefault, (__bridge CFStringRef)tokenizeText, CFRangeMake(0, CFStringGetLength((__bridge CFStringRef)tokenizeText)), kCFStringTokenizerUnitWordBoundary, locale);
     CFStringTokenizerTokenType tokenType = kCFStringTokenizerTokenNone;
 
     while (kCFStringTokenizerTokenNone != (tokenType = CFStringTokenizerAdvanceToNextToken(tokenizer))) {
@@ -35,6 +35,12 @@
 
     // Remove any stop words
     if (self.stopWords) [tokens minusSet:self.stopWords];
+
+    // Remove any space token created by using kCFStringTokenizerUnitWordBoundary
+    NSString *spaceToken = @" ";
+    if ([tokens containsObject:spaceToken]) {
+        [tokens removeObject:spaceToken];
+    }
 
     return tokens;
 }

--- a/Tests/Logic/Search/RKSearchTest.m
+++ b/Tests/Logic/Search/RKSearchTest.m
@@ -60,4 +60,51 @@
     }];
 }
 
+- (void)testSearchingForManagedObjectsWithSymbols
+{
+    __block NSError *error;
+    NSURL *modelURL = [[RKTestFixture fixtureBundle] URLForResource:@"Data Model" withExtension:@"mom"];
+    NSManagedObjectModel *managedObjectModel = [[NSManagedObjectModel alloc] initWithContentsOfURL:modelURL];
+    RKManagedObjectStore *managedObjectStore = [[RKManagedObjectStore alloc] initWithManagedObjectModel:managedObjectModel];
+    [managedObjectStore addSearchIndexingToEntityForName:@"Cat" onAttributes:@[ @"name" ]];
+    [managedObjectStore addInMemoryPersistentStore:&error];
+    [managedObjectStore createManagedObjectContexts];
+    [managedObjectStore startIndexingPersistentStoreManagedObjectContext];
+    
+    // Get some content into the index
+    RKCat *cat1 = [NSEntityDescription insertNewObjectForEntityForName:@"Cat" inManagedObjectContext:managedObjectStore.mainQueueManagedObjectContext];
+    cat1.name = @"$";
+    RKCat *cat2 = [NSEntityDescription insertNewObjectForEntityForName:@"Cat" inManagedObjectContext:managedObjectStore.mainQueueManagedObjectContext];
+    cat2.name = @"£ sterling";
+    RKCat *cat3 = [NSEntityDescription insertNewObjectForEntityForName:@"Cat" inManagedObjectContext:managedObjectStore.mainQueueManagedObjectContext];
+    cat3.name = @"€ euro";
+    
+    [managedObjectStore.mainQueueManagedObjectContext obtainPermanentIDsForObjects:@[cat1, cat2] error:&error];
+    [managedObjectStore.mainQueueManagedObjectContext saveToPersistentStore:&error];
+    
+    // Execute fetches to verify
+    [managedObjectStore.persistentStoreManagedObjectContext performBlockAndWait:^{
+        NSPredicate *predicate = [RKSearchPredicate searchPredicateWithText:@"$" type:NSAndPredicateType];
+        
+        NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Cat"];
+        fetchRequest.predicate = predicate;
+        NSArray *objects = [managedObjectStore.persistentStoreManagedObjectContext executeFetchRequest:fetchRequest error:&error];
+        assertThat(objects, hasCountOf(1));
+        assertThat([objects[0] objectID], is(equalTo(cat1.objectID)));
+    }];
+    
+    [managedObjectStore.persistentStoreManagedObjectContext performBlockAndWait:^{
+        NSPredicate *predicate = [RKSearchPredicate searchPredicateWithText:@"$ £ €" type:NSOrPredicateType];
+        
+        NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Cat"];
+        fetchRequest.predicate = predicate;
+        fetchRequest.sortDescriptors = @[ [NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES] ];
+        NSArray *objects = [managedObjectStore.persistentStoreManagedObjectContext executeFetchRequest:fetchRequest error:&error];
+        assertThat(objects, hasCountOf(3));
+        assertThat([objects[0] objectID], is(equalTo(cat1.objectID))); // $
+        assertThat([objects[1] objectID], is(equalTo(cat2.objectID))); // £
+        assertThat([objects[2] objectID], is(equalTo(cat3.objectID))); // €
+    }];
+}
+
 @end

--- a/Tests/Logic/Support/RKStringTokenizerTest.m
+++ b/Tests/Logic/Support/RKStringTokenizerTest.m
@@ -23,12 +23,29 @@
     expect(tokens).to.equal(expectedTokens);
 }
 
+- (void)testTokenizingStringWithSymbols
+{
+    RKStringTokenizer *stringTokenizer = [RKStringTokenizer new];
+    NSSet *tokens = [stringTokenizer tokenize:@"This is a symbol test! $"];
+    NSSet *expectedTokens = [NSSet setWithArray:@[ @"this", @"is", @"a", @"symbol", @"test", @"!", @"$" ]];
+    expect(tokens).to.equal(expectedTokens);
+}
+
 - (void)testTokenizingStringWithStopWords
 {
     RKStringTokenizer *stringTokenizer = [RKStringTokenizer new];
     stringTokenizer.stopWords = [NSSet setWithObjects:@"is", @"a", nil];
-    NSSet *tokens = [stringTokenizer tokenize:@"This is a test"];
-    NSSet *expectedTokens = [NSSet setWithArray:@[ @"this", @"test" ]];
+    NSSet *tokens = [stringTokenizer tokenize:@"This is a stop word test"];
+    NSSet *expectedTokens = [NSSet setWithArray:@[ @"this", @"stop", @"word", @"test" ]];
+    expect(tokens).to.equal(expectedTokens);
+}
+
+- (void)testTokenizingStringWithStopWordsAndSymbols
+{
+    RKStringTokenizer *stringTokenizer = [RKStringTokenizer new];
+    stringTokenizer.stopWords = [NSSet setWithObjects:@"is", @"a", @"!", @"%",  nil];
+    NSSet *tokens = [stringTokenizer tokenize:@"This is a stop word symbol test! # %"];
+    NSSet *expectedTokens = [NSSet setWithArray:@[ @"this", @"stop", @"word", @"symbol", @"test", @"#" ]];
     expect(tokens).to.equal(expectedTokens);
 }
 


### PR DESCRIPTION
…(#2516)

* Changed the `RKStringTokenizer` method `- (NSSet *)tokenize:(NSString *)string` to use `kCFStringTokenizerUnitWordBoundary` instead of `kCFStringTokenizerUnitWord`. This then allows tokens to be created for symbols such as '@', '$' and '#' and therefore making them searchable.

As a result of using `kCFStringTokenizerUnitWordBoundary` instead of `kCFStringTokenizerUnitWord`, spaces are detected and a token created. As we don't want to be returning results that include a space, this token (if it exists) is removed before the tokens are returned.

Unit tests added to cover both the creating of tokens from strings that contain symbols and searching for managed objects that contain symbols.

* Core formatting - removed tabs from empty lines in RKStringTokenizer.

* Fixed assert mistake in RKSearchTest unit test `testSearchingForManagedObjectsWithSymbols`.